### PR TITLE
Enable exclusion of components that have been ignored in the BOM

### DIFF
--- a/export_spdx/config.py
+++ b/export_spdx/config.py
@@ -29,6 +29,8 @@ parser.add_argument("-b", "--basic",
                     help='''Do not export copyright, download link  or package file data (speeds up processing -
                     same as using "--download_loc --no_copyrights --no_files")''',
                     action='store_true')
+parser.add_argument("--exclude_ignored_components",
+                    help="Exclude components marked ignored in the BOM", action='store_true')
 parser.add_argument("--blackduck_url", type=str,
                     help="Black Duck server URL (can also be set as env. var. BLACKDUCK_URL)", default="")
 parser.add_argument("--blackduck_api_token", type=str,

--- a/export_spdx/data.py
+++ b/export_spdx/data.py
@@ -125,7 +125,7 @@ def get_package_supplier(comp):
     return ''
 
 
-def get_bom_components(verdict):
+def get_bom_components(verdict, exclude_ignored=False):
     comp_dict = {}
     res = globals.bd.list_resources(verdict)
     # if 'components' not in res:
@@ -141,6 +141,8 @@ def get_bom_components(verdict):
     #     bom_comps = globals.bd.get_resource('components', parent=ver)
     for comp in bom_comps:
         if 'componentVersion' not in comp:
+            continue
+        if 'ignored' in comp and exclude_ignored and comp['ignored']:
             continue
         compver = comp['componentVersion']
 

--- a/export_spdx/main.py
+++ b/export_spdx/main.py
@@ -23,6 +23,10 @@ api = os.environ.get('BLACKDUCK_API_TOKEN')
 if config.args.blackduck_api_token:
     api = config.args.blackduck_api_token
 
+exclude_ignored_components = os.environ.get('EXCLUDE_IGNORED_COMPONENTS')
+if config.args.exclude_ignored_components:
+    exclude_ignored_components = config.args.exclude_ignored_components
+
 if config.args.blackduck_trust_certs:
     globals.verify = False
 
@@ -130,7 +134,7 @@ def run():
     else:
         hierarchical_bom = []
 
-    process.process_project(project, version, toppackage, hierarchical_bom, bearer_token)
+    process.process_project(project, version, toppackage, hierarchical_bom, bearer_token, exclude_ignored_components)
 
     print("Done")
 

--- a/export_spdx/process.py
+++ b/export_spdx/process.py
@@ -224,12 +224,12 @@ def process_comp_relationship(parentname, childname, mtypes):
                 break
 
 
-def process_project(project, version, projspdxname, hcomps, bearer_token):
+def process_project(project, version, projspdxname, hcomps, bearer_token, exclude_ignored=False):
     # project, version = check_projver(proj, ver)
 
     start_time = time.time()
     print('Getting component list ... ', end='')
-    bom_compsdict = data.get_bom_components(version)
+    bom_compsdict = data.get_bom_components(version, exclude_ignored)
     print("({})".format(str(len(bom_compsdict))))
     if config.args.debug:
         print("--- %s seconds ---" % (time.time() - start_time))


### PR DESCRIPTION
Adding the command switch to be able to exclude components from the SPDX export which have been ignored in the BOM in Black Duck.  This is a requested feature by a customer.  This change is intended to be backwards compatible and have no impacts on existing users of the script.