### PR TITLE
Retrieve component's homepage from Component link

### DIFF
--- a/export_spdx/process.py
+++ b/export_spdx/process.py
@@ -581,6 +581,17 @@ async def async_get_url(session, comp, token):
         result_data = await resp.json()
         if 'url' in result_data.keys():
             url = result_data['url']
+
+    if url == "NOASSERTION":        
+        hrefs = comp['_meta']['links']        
+        componentLink = next((item for item in hrefs if item["rel"] == "component-home"), None)        
+        if componentLink is None:            
+            url = "NOASSERTION"            
+            if config.args.debug:                
+                print('Component Name:' + comp['componentName'] + ' - ' + 'Component Link:' + url)       
+        else:            
+            url = componentLink['href']
+
     return comp['componentVersion'], url
 
 


### PR DESCRIPTION
Observed that the "Component link" is available to BD database and can be exported in csv file, but is not included in SBOM JSON exported file. So this commit will enchance this script, in case the homepage is empty, to retrieve this info from ['_meta']['links'] of each component