### PR TITLE
Fix spelling with respect to json schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # Synopsys Black Duck - bd_export_spdx22_json.py v0.24
+
+# DEPRECATION NOTICE
+This project is no longer maintained and is archived.
+The functionality of this script has been superceded by features in standard Black Duck, which should be used for SPDX export going forward. SPDX and CycloneDX export is supported within Project Versions under the Report tab.
+
+
 # OVERVIEW
 
 This script is provided under an OSS license (specified in the LICENSE file) to allow users to export SPDX version 2.2 in JSON format from Black Duck projects.

--- a/export_spdx/process.py
+++ b/export_spdx/process.py
@@ -114,9 +114,9 @@ def process_comp(comps_dict, tcomp, comp_data_dict):
             packagesuppliername = packagesuppliername + "NOASSERTION"
 
         # TO DO - use packagesuppliername somewhere
-
+        component_version_ref = tcomp['componentVersion'].split('/')[-1]
         thisdict = {
-            "SPDXID": spdx.quote(spdxpackage_name),
+            "SPDXID": 'SPDXRef-package-' + component_version_ref,
             "name": spdx.quote(tcomp['componentName']),
             "versionInfo": spdx.quote(tcomp['componentVersionName']),
             "packageFileName": spdx.quote(package_file),
@@ -526,8 +526,8 @@ async def async_get_licenses(session, lcomp, token):
             else:
                 # Custom license
                 try:
-                    thislic = 'LicenseRef-' + spdx.clean_for_spdx(lic['licenseDisplay'] + '-' + lcomp['componentName'])
                     lic_ref = lic['license'].split("/")[-1]
+                    thislic = 'LicenseRef-' + lic_ref
                     headers = {
                         'accept': "text/plain",
                         'Authorization': f'Bearer {token}',

--- a/export_spdx/process.py
+++ b/export_spdx/process.py
@@ -539,7 +539,7 @@ async def async_get_licenses(session, lcomp, token):
                         lic_text = await resp.text('utf-8')
                         if thislic not in globals.spdx_lics:
                             mydict = {
-                                'licenseID': spdx.quote(thislic),
+                                'licenseId': spdx.quote(thislic),
                                 'extractedText': spdx.quote(lic_text)
                             }
                             globals.spdx["hasExtractedLicensingInfos"].append(mydict)


### PR DESCRIPTION
Fix spelling of licenseId with respect to json schema validation, which is case sensitive. 

Addresses one problem in #15 .

_Fabian Faulhaber, fabian.faulhaber@mercedes-benz.com, on behalf of [Mercedes-Benz Tech Innovation GmbH](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)._